### PR TITLE
Don't load racc/parser, not necessary when using an embedded parser

### DIFF
--- a/lib/ridl/scanner.rb
+++ b/lib/ridl/scanner.rb
@@ -9,7 +9,6 @@
 #
 # Copyright (c) Remedy IT Expertise BV
 #--------------------------------------------------------------------
-require 'racc/parser'
 require 'delegate'
 
 module IDL


### PR DESCRIPTION
    * lib/ridl/scanner.rb: