### PR TITLE
Revert "Don't load racc/parser, not necessary when using an embedded parser"

### DIFF
--- a/lib/ridl/scanner.rb
+++ b/lib/ridl/scanner.rb
@@ -9,6 +9,7 @@
 #
 # Copyright (c) Remedy IT Expertise BV
 #--------------------------------------------------------------------
+require 'racc/parser'
 require 'delegate'
 
 module IDL


### PR DESCRIPTION
Reverts RemedyIT/ridl#76