### PR TITLE
Bound or array size is defined as positive, zero is not a valid value

### DIFF
--- a/lib/ridl/delegate.rb
+++ b/lib/ridl/delegate.rb
@@ -652,6 +652,8 @@ class Delegator
         raise "must be integer: #{_expression.value.inspect}"
       elsif _expression.value.negative?
         raise "must be positive integer: #{_expression.value}"
+      elsif _expression.value.zero?
+        raise "must be positive integer"
       end
 
       _expression.value


### PR DESCRIPTION
    * lib/ridl/delegate.rb: