### PR TITLE
Update taox11.yml

### DIFF
--- a/.github/workflows/taox11.yml
+++ b/.github/workflows/taox11.yml
@@ -54,7 +54,7 @@ jobs:
             CXX: g++-10
             ruby: '2.7'
             PackageDeps: g++-10
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: gcc-11
             CXX: g++-11
             ruby: '3.0'

--- a/.github/workflows/taox11.yml
+++ b/.github/workflows/taox11.yml
@@ -69,12 +69,11 @@ jobs:
             CXX: g++-12
             ruby: '3.2'
             PackageDeps: g++-12
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             CC: gcc-13
             CXX: g++-13
             ruby: '3.2'
             PackageDeps: g++-13
-            Repo: ppa:ubuntu-toolchain-r/test
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.CXX }} ruby-${{ matrix.ruby }}
     env:

--- a/.github/workflows/taox11.yml
+++ b/.github/workflows/taox11.yml
@@ -74,6 +74,7 @@ jobs:
             CXX: g++-13
             ruby: '3.2'
             PackageDeps: g++-13
+            Repo: ppa:ubuntu-toolchain-r/test
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.CXX }} ruby-${{ matrix.ruby }}
     env:


### PR DESCRIPTION
gcc-13 has been removed from ubuntu-22.04, see https://github.com/actions/runner-images/issues/9866